### PR TITLE
chore: update workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2.2.1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set node version to v16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
-          cache: pnpm
 
       - run: npx conventional-github-releaser -p angular
         env:


### PR DESCRIPTION
- update `checkout` and  `setup-node` action to v3
- remove `pnpm/action-setup` and dependencies cache
- set `fetch-depth: 0` (By default, shallow checkout causes `conventional-github-releaser` not be able to generate full release notes)