### PR TITLE
fix: update entry point to .cjs and broaden build task matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": "Build start",
-            "endsPattern": "(B|Reb)uild complete"
+            "endsPattern": "(B|Reb)uild complete|Rebuilt in"
           }
         }
       ],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "categories": [
     "Other"
   ],
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "icon": "res/icon.png",
   "files": [
     "LICENSE.md",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x] <- Keep this line and put an `x` between the brackts.

### Description

Use this template and start. But I found the initial project can not debug. Here are the screenshots.

<img width="471" height="200" alt="image" src="https://github.com/user-attachments/assets/f61eecf4-4910-4310-a7f1-1eb9c7bc59ea" />

- Update "main" in package.json to "./dist/index.cjs" to match actual build output.

<img width="1192" height="241" alt="image" src="https://github.com/user-attachments/assets/5673c98a-179e-4e97-8c76-c7e3f71f0a5d" />

- Enhance problemMatcher in tasks.json to support "Rebuilt in" pattern, ensuring compatibility with tsdown.

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->



