### PR TITLE
fix: update the deprecated VS Marketplace Shields.io badge to a Badgen one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ext-name
 
-<a href="https://marketplace.visualstudio.com/items?itemName=antfu.ext-name" target="__blank"><img src="https://badgen.net/vs-marketplace/v/antfu.ext-name?color=eee&label=VS%20Code%20Marketplace" alt="Visual Studio Marketplace Version" /></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=antfu.ext-name" target="__blank"><img src="https://badgen.net/vs-marketplace/v/antfu.ext-name?color=333&label=VS%20Code%20Marketplace" alt="Visual Studio Marketplace Version" /></a>
 <a href="https://kermanx.github.io/reactive-vscode/" target="__blank"><img src="https://img.shields.io/badge/made_with-reactive--vscode-%23007ACC?style=flat&labelColor=%23229863"  alt="Made with reactive-vscode" /></a>
 
 ## Configurations

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ext-name
 
-<a href="https://marketplace.visualstudio.com/items?itemName=antfu.ext-name" target="__blank"><img src="https://img.shields.io/visual-studio-marketplace/v/antfu.ext-name.svg?color=eee&amp;label=VS%20Code%20Marketplace&logo=visual-studio-code" alt="Visual Studio Marketplace Version" /></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=antfu.ext-name" target="__blank"><img src="https://badgen.net/vs-marketplace/v/antfu.ext-name?color=eee&label=VS%20Code%20Marketplace" alt="Visual Studio Marketplace Version" /></a>
 <a href="https://kermanx.github.io/reactive-vscode/" target="__blank"><img src="https://img.shields.io/badge/made_with-reactive--vscode-%23007ACC?style=flat&labelColor=%23229863"  alt="Made with reactive-vscode" /></a>
 
 ## Configurations


### PR DESCRIPTION
Hi! 👋 

### 🧭 Context

The [VS Marketplace Shields.io badges have been deprecated](https://github.com/badges/shields/pull/11792) and are [no longer showing the expected values](https://github.com/antfu/starter-vscode/blob/0a543c8e9969cbeb6b4838b889caf8abe7119bc6/README.md#ext-name).

### 📚 Description

This PR switches it over to [Badgen](https://badgen.net/), a similar service that's under [active development](https://github.com/badgen/badgen.net).

The logo/[icon](https://badgen.net/help#options) URL param was removed since [Simple Icons doesn't have the VS Code logo available](https://github.com/simple-icons/simple-icons/issues/11236).

Additionally, [Badgen doesn't support an algorithm to choose colors based on the background](https://github.com/badgen/badgen/issues/67), nor does it allow for manual text color selection. So, I chose to use the font color from the Shields.io badge as the background color for the new badge to ensure proper contrast and maintain the aesthetic.

- New badge example: https://badgen.net/vs-marketplace/v/Vue.volar?color=333&label=VS%20Code%20Marketplace
- Previous badge: https://img.shields.io/visual-studio-marketplace/v/antfu.ext-name.svg?color=eee&label=VS%20Code%20Marketplace&logo=visual-studio-code

Thanks!

P.S.: Since this is a template, I considered this change to be a [code change](https://github.com/antfu/contribute#commit-convention), which is why I used `fix:` instead of `docs:`. Let me know if I should change it.
